### PR TITLE
Added tests for Separations retirement behavior

### DIFF
--- a/src/separations.h
+++ b/src/separations.h
@@ -79,7 +79,7 @@ class Separations : public cyclus::Facility {
       std::vector<std::pair<cyclus::Trade<cyclus::Material>,
                             cyclus::Material::Ptr> >& responses);
 
-  bool CheckDecommissionCondition();
+  virtual bool CheckDecommissionCondition();
 
   #pragma cyclus clone
   #pragma cyclus initfromcopy

--- a/src/separations.h
+++ b/src/separations.h
@@ -79,6 +79,8 @@ class Separations : public cyclus::Facility {
       std::vector<std::pair<cyclus::Trade<cyclus::Material>,
                             cyclus::Material::Ptr> >& responses);
 
+  bool CheckDecommissionCondition();
+
   #pragma cyclus clone
   #pragma cyclus initfromcopy
   #pragma cyclus infiletodb


### PR DESCRIPTION
Tests that separations stops requesting material to prepare for retirement, then discharges all of the remaining material.
